### PR TITLE
feat: export routes

### DIFF
--- a/.changeset/mighty-plants-exist.md
+++ b/.changeset/mighty-plants-exist.md
@@ -1,0 +1,5 @@
+---
+'sv-router': patch
+---
+
+export route type

--- a/.changeset/mighty-plants-exist.md
+++ b/.changeset/mighty-plants-exist.md
@@ -2,4 +2,4 @@
 'sv-router': patch
 ---
 
-export route type
+Export route type

--- a/src/gen/generate-router-code.js
+++ b/src/gen/generate-router-code.js
@@ -177,7 +177,7 @@ export function createRouterCode(routes, routesPath, { allLazy = false } = {}) {
 		`import { createRouter } from 'sv-router';`,
 		...imports,
 		'',
-		`const routes = Object.freeze(${stringifiedRoutes} as const);`,
+		`const routes = ${stringifiedRoutes};`,
 		'export type Routes = typeof routes;',
 		'export const { p, navigate, isActive, preload, route } = createRouter(routes);',
 	].join('\n');

--- a/src/gen/generate-router-code.js
+++ b/src/gen/generate-router-code.js
@@ -177,7 +177,7 @@ export function createRouterCode(routes, routesPath, { allLazy = false } = {}) {
 		`import { createRouter } from 'sv-router';`,
 		...imports,
 		'',
-		`export const routes = Object.freeze(${stringifiedRoutes} as const);`,
+		`const routes = Object.freeze(${stringifiedRoutes} as const);`,
 		'export type Routes = typeof routes;',
 		'export const { p, navigate, isActive, preload, route } = createRouter(routes);',
 	].join('\n');

--- a/src/gen/generate-router-code.js
+++ b/src/gen/generate-router-code.js
@@ -177,7 +177,9 @@ export function createRouterCode(routes, routesPath, { allLazy = false } = {}) {
 		`import { createRouter } from 'sv-router';`,
 		...imports,
 		'',
-		`export const { p, navigate, isActive, preload, route } = createRouter(${stringifiedRoutes});`,
+		`export const routes = Object.freeze(${stringifiedRoutes} as const);`,
+		'export type Routes = typeof routes;',
+		'export const { p, navigate, isActive, preload, route } = createRouter(routes);',
 	].join('\n');
 }
 

--- a/tests/generate-router-code.test.js
+++ b/tests/generate-router-code.test.js
@@ -20,7 +20,7 @@ import Index from '../a/fake/path/index.svelte';
 import PostsStatic from '../a/fake/path/posts.static.svelte';
 import PostsNolayout from '../a/fake/path/posts.(nolayout).svelte';
 
-const routes = Object.freeze({
+const routes = {
   '*notfound': () => import('../a/fake/path/[...notfound].lazy.svelte'),
   '/about': About,
   '/': Index,
@@ -29,7 +29,7 @@ const routes = Object.freeze({
   '/posts/static': PostsStatic,
   '/posts/(nolayout)': PostsNolayout,
   '/posts/comments/:id': () => import('../a/fake/path/posts.comments.[id].lazy.svelte')
-} as const);
+};
 export type Routes = typeof routes;
 export const { p, navigate, isActive, preload, route } = createRouter(routes);`);
 	});
@@ -48,7 +48,7 @@ import postsMeta from '../a/fake/path/posts/meta.svelte';
 import postsCommentsHooks from '../a/fake/path/posts/comments/hooks.svelte';
 import postsCommentsMeta from '../a/fake/path/posts/comments/meta';
 
-const routes = Object.freeze({
+const routes = {
   '*notfound': () => import('../a/fake/path/[...notfound].lazy.svelte'),
   '/about': About,
   '/': Index,
@@ -66,7 +66,7 @@ const routes = Object.freeze({
       'meta': postsCommentsMeta
     }
   }
-} as const);
+};
 export type Routes = typeof routes;
 export const { p, navigate, isActive, preload, route } = createRouter(routes);`);
 	});
@@ -242,7 +242,7 @@ import PostsCommentsCommentId from './routes/posts/comments/[commentId].svelte';
 import postsCommentsHooks from './routes/posts/comments/hooks.svelte';
 import postsCommentsMeta from './routes/posts/comments/meta.svelte';
 
-const routes = Object.freeze({
+const routes = {
   '/': Index,
   '/about': About,
   '/posts': {
@@ -259,7 +259,7 @@ const routes = Object.freeze({
     }
   },
   '*notfound': () => import('./routes/[...notfound].lazy.svelte')
-} as const);
+};
 export type Routes = typeof routes;
 export const { p, navigate, isActive, preload, route } = createRouter(routes);`);
 	});
@@ -272,7 +272,7 @@ import postsMeta from './routes/posts/meta';
 import postsCommentsHooks from './routes/posts/comments/hooks.svelte';
 import postsCommentsMeta from './routes/posts/comments/meta.svelte';
 
-const routes = Object.freeze({
+const routes = {
   '/': () => import('./routes/index.svelte'),
   '/about': () => import('./routes/about.svelte'),
   '/posts': {
@@ -289,7 +289,7 @@ const routes = Object.freeze({
     }
   },
   '*notfound': () => import('./routes/[...notfound].lazy.svelte')
-} as const);
+};
 export type Routes = typeof routes;
 export const { p, navigate, isActive, preload, route } = createRouter(routes);`);
 	});

--- a/tests/generate-router-code.test.js
+++ b/tests/generate-router-code.test.js
@@ -20,7 +20,7 @@ import Index from '../a/fake/path/index.svelte';
 import PostsStatic from '../a/fake/path/posts.static.svelte';
 import PostsNolayout from '../a/fake/path/posts.(nolayout).svelte';
 
-export const { p, navigate, isActive, preload, route } = createRouter({
+export const routes = Object.freeze({
   '*notfound': () => import('../a/fake/path/[...notfound].lazy.svelte'),
   '/about': About,
   '/': Index,
@@ -29,7 +29,9 @@ export const { p, navigate, isActive, preload, route } = createRouter({
   '/posts/static': PostsStatic,
   '/posts/(nolayout)': PostsNolayout,
   '/posts/comments/:id': () => import('../a/fake/path/posts.comments.[id].lazy.svelte')
-});`);
+} as const);
+export type Routes = typeof routes;
+export const { p, navigate, isActive, preload, route } = createRouter(routes);`);
 	});
 
 	it('should generate the router code (tree)', () => {
@@ -46,7 +48,7 @@ import postsMeta from '../a/fake/path/posts/meta.svelte';
 import postsCommentsHooks from '../a/fake/path/posts/comments/hooks.svelte';
 import postsCommentsMeta from '../a/fake/path/posts/comments/meta';
 
-export const { p, navigate, isActive, preload, route } = createRouter({
+export const routes = Object.freeze({
   '*notfound': () => import('../a/fake/path/[...notfound].lazy.svelte'),
   '/about': About,
   '/': Index,
@@ -64,7 +66,9 @@ export const { p, navigate, isActive, preload, route } = createRouter({
       'meta': postsCommentsMeta
     }
   }
-});`);
+} as const);
+export type Routes = typeof routes;
+export const { p, navigate, isActive, preload, route } = createRouter(routes);`);
 	});
 });
 
@@ -238,7 +242,7 @@ import PostsCommentsCommentId from './routes/posts/comments/[commentId].svelte';
 import postsCommentsHooks from './routes/posts/comments/hooks.svelte';
 import postsCommentsMeta from './routes/posts/comments/meta.svelte';
 
-export const { p, navigate, isActive, preload, route } = createRouter({
+export const routes = Object.freeze({
   '/': Index,
   '/about': About,
   '/posts': {
@@ -255,7 +259,9 @@ export const { p, navigate, isActive, preload, route } = createRouter({
     }
   },
   '*notfound': () => import('./routes/[...notfound].lazy.svelte')
-});`);
+} as const);
+export type Routes = typeof routes;
+export const { p, navigate, isActive, preload, route } = createRouter(routes);`);
 	});
 
 	it('should generate the router code with only lazy routes', () => {
@@ -266,7 +272,7 @@ import postsMeta from './routes/posts/meta';
 import postsCommentsHooks from './routes/posts/comments/hooks.svelte';
 import postsCommentsMeta from './routes/posts/comments/meta.svelte';
 
-export const { p, navigate, isActive, preload, route } = createRouter({
+export const routes = Object.freeze({
   '/': () => import('./routes/index.svelte'),
   '/about': () => import('./routes/about.svelte'),
   '/posts': {
@@ -283,7 +289,9 @@ export const { p, navigate, isActive, preload, route } = createRouter({
     }
   },
   '*notfound': () => import('./routes/[...notfound].lazy.svelte')
-});`);
+} as const);
+export type Routes = typeof routes;
+export const { p, navigate, isActive, preload, route } = createRouter(routes);`);
 	});
 });
 

--- a/tests/generate-router-code.test.js
+++ b/tests/generate-router-code.test.js
@@ -20,7 +20,7 @@ import Index from '../a/fake/path/index.svelte';
 import PostsStatic from '../a/fake/path/posts.static.svelte';
 import PostsNolayout from '../a/fake/path/posts.(nolayout).svelte';
 
-export const routes = Object.freeze({
+const routes = Object.freeze({
   '*notfound': () => import('../a/fake/path/[...notfound].lazy.svelte'),
   '/about': About,
   '/': Index,
@@ -48,7 +48,7 @@ import postsMeta from '../a/fake/path/posts/meta.svelte';
 import postsCommentsHooks from '../a/fake/path/posts/comments/hooks.svelte';
 import postsCommentsMeta from '../a/fake/path/posts/comments/meta';
 
-export const routes = Object.freeze({
+const routes = Object.freeze({
   '*notfound': () => import('../a/fake/path/[...notfound].lazy.svelte'),
   '/about': About,
   '/': Index,
@@ -242,7 +242,7 @@ import PostsCommentsCommentId from './routes/posts/comments/[commentId].svelte';
 import postsCommentsHooks from './routes/posts/comments/hooks.svelte';
 import postsCommentsMeta from './routes/posts/comments/meta.svelte';
 
-export const routes = Object.freeze({
+const routes = Object.freeze({
   '/': Index,
   '/about': About,
   '/posts': {
@@ -272,7 +272,7 @@ import postsMeta from './routes/posts/meta';
 import postsCommentsHooks from './routes/posts/comments/hooks.svelte';
 import postsCommentsMeta from './routes/posts/comments/meta.svelte';
 
-export const routes = Object.freeze({
+const routes = Object.freeze({
   '/': () => import('./routes/index.svelte'),
   '/about': () => import('./routes/about.svelte'),
   '/posts': {


### PR DESCRIPTION
Export and freeze routes in generated code.

Useful for user defined wrapper components (Link -> ConstructPathArgs) etc.