### PR TITLE
feat: allow arbitrary search params and anchors in `p`

### DIFF
--- a/src/actions.svelte.js
+++ b/src/actions.svelte.js
@@ -8,7 +8,7 @@ export function isActiveLink(node, { className = 'is-active', startsWith = false
 	}
 
 	$effect(() => {
-		let pathname = new URL(node.href).pathname;
+		let pathname = new URL(node.href, globalThis.location.origin).pathname;
 		if (base.name) {
 			pathname = join(base.name, pathname);
 		}

--- a/src/create-router.svelte.js
+++ b/src/create-router.svelte.js
@@ -172,7 +172,7 @@ export function onGlobalClick(event) {
 
 	if (anchor.hasAttribute('target') || anchor.hasAttribute('download')) return;
 
-	const url = new URL(anchor.href);
+	const url = new URL(anchor.href, globalThis.location.origin);
 	const currentOrigin = globalThis.location.origin;
 	if (url.origin !== currentOrigin) return;
 

--- a/src/helpers/match-route.js
+++ b/src/helpers/match-route.js
@@ -11,7 +11,7 @@
  */
 
 /**
- * @param {string} pathname
+ * @param {string} path
  * @param {Routes} routes
  * @returns {{
  * 	match: RouteComponent | undefined;
@@ -22,7 +22,8 @@
  * 	breakFromLayouts: boolean;
  * }}
  */
-export function matchRoute(pathname, routes) {
+export function matchRoute(path, routes) {
+	let pathname = new URL(path, globalThis.location.origin).pathname;
 	// Remove trailing slash
 	if (pathname.length > 1 && pathname.endsWith('/')) {
 		pathname = pathname.slice(0, -1);

--- a/src/helpers/preload.js
+++ b/src/helpers/preload.js
@@ -7,9 +7,10 @@ import { resolveRouteComponents } from './utils.js';
  * @param {import('../index.d.ts').NavigateOptions} [options]
  */
 export async function preload(routes, path, options) {
-	const { match, layouts, hooks } = matchRoute(path, routes);
+	const pathname = new URL(path, globalThis.location.origin).pathname;
+	const { match, layouts, hooks } = matchRoute(pathname, routes);
 	for (const { onPreload } of hooks) {
-		onPreload?.({ pathname: path, ...options });
+		onPreload?.({ pathname, ...options });
 	}
 	await resolveRouteComponents(match ? [...layouts, match] : layouts);
 }
@@ -30,9 +31,9 @@ export function preloadOnHover(routes) {
 				link.removeEventListener('mouseenter', callback);
 				const href = link.getAttribute('href');
 				if (!href) return;
-				const url = new URL(link.href);
+				const url = new URL(link.href, globalThis.location.origin);
 				const { replace, state } = link.dataset;
-				preload(routes, href, {
+				void preload(routes, url.pathname, {
 					replace: replace === '' || replace === 'true',
 					search: url.search,
 					state,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -213,12 +213,12 @@ export type IsActiveArgs<T extends string> =
 	PathParams<T> extends never ? [T] : [T] | [T, PathParams<T>];
 
 export type PathParams<T extends string> =
-	ExtractParams<RemoveParenthesis<T>> extends never
+	ExtractParams<CleanPathForParams<T>> extends never
 		? never
-		: Record<ExtractParams<RemoveParenthesis<T>>, string>;
+		: Record<ExtractParams<CleanPathForParams<T>>, string>;
 
 export type AllParams<T extends Routes> = Partial<
-	Record<ExtractParams<RemoveParenthesis<RecursiveKeys<T>>>, string>
+	Record<ExtractParams<CleanPathForParams<RecursiveKeys<T>>>, string>
 >;
 
 export type HooksContext = {
@@ -295,6 +295,14 @@ type RemoveLastSlash<T extends string> = T extends '/' ? T : T extends `${infer 
 type RemoveParenthesis<T extends string> = T extends `${infer A}(${infer B})${infer C}`
 	? RemoveParenthesis<`${A}${B}${C}`>
 	: T;
+
+type RemoveSearchAndHash<T extends string> = T extends `${infer Path}?${string}`
+	? RemoveSearchAndHash<Path>
+	: T extends `${infer Path}#${string}`
+		? RemoveSearchAndHash<Path>
+		: T;
+
+type CleanPathForParams<T extends string> = RemoveParenthesis<RemoveSearchAndHash<T>>;
 
 type ExtractParams<T extends string> = T extends `${string}:${infer Param}/${infer Rest}`
 	? Param | ExtractParams<`/${Rest}`>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -104,12 +104,16 @@ export type RouterApi<T extends Routes> = {
 	 * p('/users');
 	 * // With parameters
 	 * p('/users/:id', { id: 1 });
+	 * // With arbitrary search params
+	 * p('/users/:id?modal=cancel, { id: 1 });
+	 * // With arbitrary anchor
+	 * p('/users/:id#cancel', { id: 1 });
 	 * ```
 	 *
 	 * @param route The route to navigate to.
 	 * @param params The parameters to replace in the route.
 	 */
-	p<U extends Path<T>>(...args: ConstructPathArgs<U>): string;
+	p<U extends PathWithSearchAndHash<T>>(...args: ConstructPathArgs<U>): string;
 
 	/**
 	 * Navigate programmatically to a route.
@@ -151,7 +155,7 @@ export type RouterApi<T extends Routes> = {
 	 *
 	 * @param path The route to preload.
 	 */
-	preload<U extends Path<T>>(path: U): Promise<void>;
+	preload<U extends PathWithSearchAndHash<T>>(path: U): Promise<void>;
 
 	route: {
 		/**
@@ -185,6 +189,14 @@ export type RouterApi<T extends Routes> = {
 		meta: RouteMeta;
 	};
 };
+
+export type AppendSearchAndHash<Path extends string> =
+	`${Path}${'' | `?${string}`}${'' | `#${string}`}`;
+
+export type PathWithSearchAndHash<
+	T extends Routes,
+	AnyParam extends boolean = false,
+> = AppendSearchAndHash<Path<T, AnyParam>>;
 
 export type Path<T extends Routes, AnyParam extends boolean = false> = RemoveParenthesis<
 	RemoveLastSlash<RecursiveKeys<StripNonRoutes<T>, '', AnyParam>>


### PR DESCRIPTION
Allows any search param or anchor in the `p` function.

Also solidifies creation of URLs.
`const url = new URL("/")` throws an error, we don't want that. I haven't come across it but it seemed like a fitting change/improvement next to these.

EDIT:
But it seems like I fixed preloading (atleast some edge-case) with this change, but not sure, maybe affected only our codebase.