### PR TITLE
Export routes object for dynamic menu generation

### DIFF
--- a/.changeset/rude-seals-reflect.md
+++ b/.changeset/rude-seals-reflect.md
@@ -1,0 +1,5 @@
+---
+'sv-router': patch
+---
+
+Export routes object for dynamic menu generation

--- a/src/gen/generate-router-code.js
+++ b/src/gen/generate-router-code.js
@@ -216,7 +216,7 @@ export function createRouterCode(routes, routesPath, { allLazy = false, js = fal
 		`import { createRouter } from 'sv-router';`,
 		...imports,
 		'',
-		`const routes = ${stringifiedRoutes};`,
+		`export const routes = ${stringifiedRoutes};`,
 		...(js ? [] : ['export type Routes = typeof routes;']),
 		'export const { p, navigate, isActive, preload, route } = createRouter(routes);',
 		'',

--- a/tests/generate-router-code.test.js
+++ b/tests/generate-router-code.test.js
@@ -20,7 +20,7 @@ import Index from '../a/fake/path/index.svelte';
 import PostsStatic from '../a/fake/path/posts.static.svelte';
 import PostsNolayout from '../a/fake/path/posts.(nolayout).svelte';
 
-const routes = {
+export const routes = {
   '*notfound': () => import('../a/fake/path/[...notfound].lazy.svelte'),
   '/about': About,
   '/': Index,
@@ -49,7 +49,7 @@ import postsMeta from '../a/fake/path/posts/meta.svelte';
 import postsCommentsHooks from '../a/fake/path/posts/comments/hooks.svelte';
 import postsCommentsMeta from '../a/fake/path/posts/comments/meta';
 
-const routes = {
+export const routes = {
   '*notfound': () => import('../a/fake/path/[...notfound].lazy.svelte'),
   '/about': About,
   '/': Index,
@@ -285,7 +285,7 @@ import GroupLayout from './routes/_group/layout.svelte';
 import groupHooks from './routes/_group/hooks';
 import groupMeta from './routes/_group/meta';
 
-const routes = {
+export const routes = {
   '/': Index,
   '/about': About,
   '/posts': {
@@ -324,7 +324,7 @@ import postsCommentsMeta from './routes/posts/comments/meta.svelte';
 import groupHooks from './routes/_group/hooks';
 import groupMeta from './routes/_group/meta';
 
-const routes = {
+export const routes = {
   '/': () => import('./routes/index.svelte'),
   '/about': () => import('./routes/about.svelte'),
   '/posts': {
@@ -358,7 +358,7 @@ export const { p, navigate, isActive, preload, route } = createRouter(routes);
 		expect(result).toBe(`import { createRouter } from 'sv-router';
 import Index from './routes/index.svelte';
 
-const routes = {
+export const routes = {
   '/': Index
 };
 export const { p, navigate, isActive, preload, route } = createRouter(routes);


### PR DESCRIPTION
Currently, in file based routing, the generated `routes.ts` file creates the routes object but doesn't export it, making it difficult to build dynamic navigation menus that need to iterate over available routes.

### Current generated code:
```ts
const routes = {
  '/about': () => import('../src/routes/about.svelte'),
  '/': () => import('../src/routes/index.svelte')
};
```

### Proposed change:
```ts
export const routes = {
  '/about': () => import('../src/routes/about.svelte'),
  '/': () => import('../src/routes/index.svelte')
};
```

This would be a non-breaking change that enables dynamic menu generation and other use cases where programmatic access to the route configuration is needed.