### PR TITLE
chore: add a test for dynamic routes

### DIFF
--- a/tests/router/DynamicRoutes.test.svelte
+++ b/tests/router/DynamicRoutes.test.svelte
@@ -1,0 +1,26 @@
+<script module lang="ts">
+	import { createRawSnippet } from 'svelte';
+	import { createRouter } from '../../src/create-router.svelte.js';
+	import type { Routes } from '../../src/index.js';
+	import Router from '../../src/Router.svelte';
+
+	const routes: Routes = {
+		'/foo': createRawSnippet(() => ({ render: () => '<h1>Foo Page</h1>' })),
+		'/bar': createRawSnippet(() => ({ render: () => '<h1>Bar Page</h1>' })),
+		'*': createRawSnippet(() => ({ render: () => '<h1>Not Found</h1>' })),
+	};
+
+	const YoloSnippet = createRawSnippet(() => ({ render: () => '<h1>Yolo Page</h1>' }));
+
+	export const { navigate, route } = createRouter(routes);
+
+	export function setYoloRoute(enabled: boolean) {
+		if (enabled) {
+			routes['/yolo'] = YoloSnippet;
+		} else {
+			delete routes['/yolo'];
+		}
+	}
+</script>
+
+<Router />

--- a/tests/router/router.test.js
+++ b/tests/router/router.test.js
@@ -731,3 +731,60 @@ describe('blockNavigation', () => {
 		clear();
 	});
 });
+
+describe('router (dynamic routes)', () => {
+	beforeEach(() => {
+		location.pathname = '/';
+		location.search = '';
+		base.name = undefined;
+	});
+
+	it('should navigate to a dynamically added route and fall back when removed', async () => {
+		const {
+			default: DynamicApp,
+			navigate: nav,
+			setYoloRoute,
+		} = await import('./DynamicRoutes.test.svelte');
+
+		render(DynamicApp);
+		await waitFor(() => {
+			expect(screen.getByText('Not Found')).toBeInTheDocument();
+		});
+
+		// Navigate to /foo — should work since it's in the initial routes
+		await nav('/foo');
+		await waitFor(() => {
+			expect(screen.getByText('Foo Page')).toBeInTheDocument();
+		});
+
+		// /yolo is not defined yet — should show catch-all
+		await nav('/yolo');
+		await waitFor(() => {
+			expect(screen.getByText('Not Found')).toBeInTheDocument();
+		});
+
+		// Dynamically add /yolo
+		setYoloRoute(true);
+		await nav('/yolo');
+		await waitFor(() => {
+			expect(screen.getByText('Yolo Page')).toBeInTheDocument();
+		});
+
+		// Navigate away and back to confirm it still works
+		await nav('/bar');
+		await waitFor(() => {
+			expect(screen.getByText('Bar Page')).toBeInTheDocument();
+		});
+		await nav('/yolo');
+		await waitFor(() => {
+			expect(screen.getByText('Yolo Page')).toBeInTheDocument();
+		});
+
+		// Dynamically remove /yolo
+		setYoloRoute(false);
+		await nav('/yolo');
+		await waitFor(() => {
+			expect(screen.getByText('Not Found')).toBeInTheDocument();
+		});
+	});
+});


### PR DESCRIPTION
Hi,

I really appreciate this router becuase
* hard to find a good router project for svelte
* AND even harder to find one, where "dynamic" routes work

This PR adds a test which checks that a route can be added/removed dynamically at runtime.
The main reason of doing this is PR is to prevent in the future that for some reason or coincidence, the dynamic route support gets dropped silently.

If such a dynamic route support is not in favour of the author of this lib, I can understand, as no other library has this, but I'd really appreciate if this support would be kept (as it is the backbone for my app)...