### PR TITLE
feat: Add `toURLSearchParams` to `searchParams` for easier ergonomic use

### DIFF
--- a/.changeset/flat-dingos-do.md
+++ b/.changeset/flat-dingos-do.md
@@ -1,0 +1,5 @@
+---
+'sv-router': patch
+---
+
+Add `toURLSearchParams` to make `searchParams` more easily usable in URLSearchParams APIs

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -316,6 +316,7 @@ export type SearchParams = Omit<
 	getAll(name: string): (string | number | boolean)[];
 	set(name: string, value: string | number | boolean, options?: { replace?: boolean }): void;
 	sort(options?: { replace?: boolean }): void;
+	toURLSearchParams(): URLSearchParams;
 	values(): (string | number | boolean)[];
 };
 

--- a/src/search-params.svelte.js
+++ b/src/search-params.svelte.js
@@ -47,6 +47,9 @@ const shell = {
 	values() {
 		return [...searchParams.values()].map(parseSearchValue);
 	},
+	toURLSearchParams() {
+		return new URLSearchParams(searchParams);
+	},
 	get size() {
 		return searchParams.size;
 	},


### PR DESCRIPTION
SearchParams is not that ergonomic to use in contexts where the more "generic" `URLSearchParams` is needed.