### PR TITLE
fix: don't intercept link clicks outside the base path

### DIFF
--- a/.changeset/eight-teeth-relate.md
+++ b/.changeset/eight-teeth-relate.md
@@ -1,0 +1,5 @@
+---
+"sv-router": patch
+---
+
+Don't intercept link clicks outside the base path

--- a/src/create-router.svelte.js
+++ b/src/create-router.svelte.js
@@ -345,6 +345,8 @@ export function onGlobalClick(event) {
 	const path = base.name === '#' ? url.hash : url.pathname;
 	const hash = base.name === '#' ? undefined : url.hash;
 
+	if (base.name && base.name !== '#' && !path.startsWith(base.name)) return;
+
 	event.preventDefault();
 	const { replace, state, scrollToTop, viewTransition } = anchor.dataset;
 

--- a/tests/router/Layout.test.svelte
+++ b/tests/router/Layout.test.svelte
@@ -16,6 +16,7 @@
 	<a href={p('/lazy')} data-preload>Lazy</a>
 	<a href={p('/after-load')}>After Load</a>
 	<a href="https://example.com" target="_blank">External</a>
+	<a href="/outside-base">Outside Base</a>
 </nav>
 
 {@render children()}

--- a/tests/router/router.test.js
+++ b/tests/router/router.test.js
@@ -132,6 +132,15 @@ describe('router', () => {
 		});
 	});
 
+	it('should not intercept links outside the base path', async () => {
+		render(App, { base: 'my-app' });
+		await waitFor(() => expect(screen.getByText('Welcome')).toBeInTheDocument());
+		const outsideLink = screen.getByText('Outside Base');
+		expect(outsideLink.closest('a')).toHaveAttribute('href', '/outside-base');
+		await userEvent.click(outsideLink);
+		expect(location.pathname).toBe('/outside-base');
+	});
+
 	it('should scroll to top after navigation', async () => {
 		render(App);
 		window.scrollY = 100;


### PR DESCRIPTION
When using the base prop (e.g. `<Router base="/app" />`), clicking an `<a href="/other">` navigates to `/app/other` instead of `/other`. The router intercepts all same-origin links regardless of whether they fall within the base path.

Fix: In `onGlobalClick`, bail out before `preventDefault()` if the link's pathname doesn't start with the base:

```js
if (base.name && base.name !== '#' && !path.startsWith(base.name)) return;
```

Fixes #293