### PR TITLE
fix: populate beforeLoad's search, hash, and state on browser navigation

### DIFF
--- a/.changeset/floppy-pans-unite.md
+++ b/.changeset/floppy-pans-unite.md
@@ -1,0 +1,5 @@
+---
+"sv-router": patch
+---
+
+Populate `beforeLoad`'s `search`, `hash`, and `state` from the current URL on browser navigation

--- a/src/create-router.svelte.js
+++ b/src/create-router.svelte.js
@@ -229,8 +229,9 @@ export async function onNavigate(path, options = {}) {
 	const matchPath = getMatchPath(path);
 	const { match, layouts, hooks, meta: newMeta, params: newParams } = matchRoute(matchPath, routes);
 
-	const search = parseSearch(options.search);
-	const hooksContext = { pathname: matchPath, meta: newMeta, ...options, search };
+	const navContext = path ? options : { ...options, ...updatedLocation() };
+	const search = parseSearch(navContext.search);
+	const hooksContext = { ...navContext, pathname: matchPath, meta: newMeta, search };
 
 	let errorHooks = [];
 	for (const hook of hooks) {

--- a/tests/router/router.test.js
+++ b/tests/router/router.test.js
@@ -257,6 +257,32 @@ describe('router', () => {
 		);
 	});
 
+	it('should pass current search, hash, and state to beforeLoad on popstate navigation', async () => {
+		render(App);
+		await waitFor(() => {
+			expect(screen.getByText('Welcome')).toBeInTheDocument();
+		});
+
+		beforeLoadMock.mockClear();
+		location.pathname = '/initial-load';
+		location.search = '?foo=bar&n=1';
+		location.hash = '#section';
+		history.replaceState({ user: 'data' }, '', location.href);
+		globalThis.dispatchEvent(new PopStateEvent('popstate'));
+
+		await waitFor(() => {
+			expect(screen.getByText('Initial Load Page')).toBeInTheDocument();
+		});
+		expect(beforeLoadMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				pathname: '/initial-load',
+				search: { foo: 'bar', n: 1 },
+				hash: '#section',
+				state: { user: 'data' },
+			}),
+		);
+	});
+
 	it('should call onError when beforeLoad throws a non-Navigation error', async () => {
 		onErrorMock.mockClear();
 		render(App);


### PR DESCRIPTION
- Closes #295