### PR TITLE
fix: encode route params

### DIFF
--- a/.changeset/sad-spiders-drum.md
+++ b/.changeset/sad-spiders-drum.md
@@ -1,0 +1,5 @@
+---
+"sv-router": minor
+---
+
+Encode route params

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -8,7 +8,7 @@ import { base } from '../create-router.svelte.js';
 export function constructPath(path, params) {
 	if (params) {
 		for (const key in params) {
-			path = path.replace(`:${key}`, String(params[key]));
+			path = path.replace(`:${key}`, encodeURIComponent(params[key]));
 		}
 	}
 

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -35,6 +35,11 @@ describe.each([
 		const result = constructPath('/posts/:id/comments/:commentId', { id: '123', commentId: '456' });
 		expect(result).toBe(`${prefix}/posts/123/comments/456`);
 	});
+
+	it('should encode route params', () => {
+		const result = constructPath('/posts/:id', { id: "foo/bar?a=b" });
+		expect(result).toBe(`${prefix}/posts/foo%2Fbar%3Fa%3Db`);
+	});
 });
 
 describe('constructUrl', () => {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -37,7 +37,7 @@ describe.each([
 	});
 
 	it('should encode route params', () => {
-		const result = constructPath('/posts/:id', { id: "foo/bar?a=b" });
+		const result = constructPath('/posts/:id', { id: 'foo/bar?a=b' });
 		expect(result).toBe(`${prefix}/posts/foo%2Fbar%3Fa%3Db`);
 	});
 });


### PR DESCRIPTION
This PR addresses an issue where parameter strings containing characters that can affect URL structure or routing are passed through without being encoded. I have updated `constructPath` to wrap the parameter values with `encodeURIComponent()`.

Since this changes the existing behavior of path resolution, please feel free to close this PR if it doesn't align with the project's direction.