### PR TITLE
fix(router): don't intercept modifier, non-primary, or prevented clicks (#310)

### DIFF
--- a/.changeset/cruel-maps-switch.md
+++ b/.changeset/cruel-maps-switch.md
@@ -1,0 +1,5 @@
+---
+"sv-router": patch
+---
+
+Don't intercept modifier, non-primary, or prevented clicks

--- a/src/create-router.svelte.js
+++ b/src/create-router.svelte.js
@@ -351,7 +351,8 @@ export function onGlobalClick(event) {
 		mouseEvent.metaKey ||
 		mouseEvent.ctrlKey ||
 		mouseEvent.shiftKey ||
-		mouseEvent.altKey
+		mouseEvent.altKey ||
+		mouseEvent.defaultPrevented
 	)
 		return;
 

--- a/src/create-router.svelte.js
+++ b/src/create-router.svelte.js
@@ -345,6 +345,16 @@ function getMatchPath(path) {
 
 /** @param {Event} event */
 export function onGlobalClick(event) {
+	const mouseEvent = /** @type {MouseEvent} */ (event);
+	if (
+		mouseEvent.button !== 0 ||
+		mouseEvent.metaKey ||
+		mouseEvent.ctrlKey ||
+		mouseEvent.shiftKey ||
+		mouseEvent.altKey
+	)
+		return;
+
 	const anchor = /** @type {HTMLElement} */ (event.target).closest('a');
 	if (!anchor) return;
 

--- a/tests/router/router.test.js
+++ b/tests/router/router.test.js
@@ -51,6 +51,32 @@ describe('router', () => {
 		});
 	});
 
+	it('should not intercept a click with a modifier key held', async () => {
+		render(App);
+		await waitFor(() => {
+			expect(screen.getByText('Welcome')).toBeInTheDocument();
+		});
+		const link = screen.getByText('About');
+		for (const modifier of ['metaKey', 'ctrlKey', 'shiftKey', 'altKey']) {
+			const event = new MouseEvent('click', { bubbles: true, cancelable: true, [modifier]: true });
+			link.dispatchEvent(event);
+			expect(event.defaultPrevented).toBe(false);
+		}
+		expect(screen.getByText('Welcome')).toBeInTheDocument();
+	});
+
+	it('should not intercept a non-primary mouse button click', async () => {
+		render(App);
+		await waitFor(() => {
+			expect(screen.getByText('Welcome')).toBeInTheDocument();
+		});
+		const link = screen.getByText('About');
+		const event = new MouseEvent('click', { bubbles: true, cancelable: true, button: 1 });
+		link.dispatchEvent(event);
+		expect(event.defaultPrevented).toBe(false);
+		expect(screen.getByText('Welcome')).toBeInTheDocument();
+	});
+
 	it('should navigate to another route programmatically', async () => {
 		render(App);
 		await waitFor(() => {

--- a/tests/router/router.test.js
+++ b/tests/router/router.test.js
@@ -77,6 +77,17 @@ describe('router', () => {
 		expect(screen.getByText('Welcome')).toBeInTheDocument();
 	});
 
+	it('should not intercept a click whose default was already prevented', async () => {
+		render(App);
+		await waitFor(() => {
+			expect(screen.getByText('Welcome')).toBeInTheDocument();
+		});
+		const link = screen.getByText('About');
+		link.addEventListener('click', (event) => event.preventDefault());
+		await userEvent.click(link);
+		expect(screen.getByText('Welcome')).toBeInTheDocument();
+	});
+
 	it('should navigate to another route programmatically', async () => {
 		render(App);
 		await waitFor(() => {


### PR DESCRIPTION
Fixes #310.

`onGlobalClick` called `event.preventDefault()` on every same-origin link click, so the browser's native link gestures were hijacked into same-tab SPA navigation. This adds an early return in the click handler when any of these is true, matching how SvelteKit handles it:

- a modifier key is held (`metaKey`/`ctrlKey`/`shiftKey`/`altKey`) — ⌘/ctrl/shift/alt-click
- the click isn't the primary button (button !== 0) — e.g. middle-click to open a new tab
- another handler already called `preventDefault()`

Covered by new tests.

We're running this in production via a fork and it's working well

Full disclosure: The code was written by Claude.